### PR TITLE
Support for secret versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <org.wso2.securevault.import.version.range>[1.1.0, 2.0.0)</org.wso2.securevault.import.version.range>
 
         <software.amazon.awssdk.version>2.17.124</software.amazon.awssdk.version>
+        <software.amazon.awssdk.aws-crt-client.version>${software.amazon.awssdk.version}-PREVIEW</software.amazon.awssdk.aws-crt-client.version>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -124,8 +125,7 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-<!--            TODO get the version from properties by appending the aws version with preview-->
-            <version>2.17.124-PREVIEW</version>
+            <version>${software.amazon.awssdk.aws-crt-client.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/org/wso2/carbon/securevault/aws/AWSSecretRepository.java
+++ b/src/main/java/org/wso2/carbon/securevault/aws/AWSSecretRepository.java
@@ -70,25 +70,36 @@ public class AWSSecretRepository implements SecretRepository {
         }
 
         String secret = alias;
-
+        String secretName = alias;
         try {
+            String secretVersion = null; //If no secret version is set, it will send the request with null set for versionID which will return the latest version from AWS Secrets Manager
+            if (alias.contains("_")) {
+                int underscoreIndex = alias.indexOf("_");
+                secretName = alias.substring(0, underscoreIndex);
+                secretVersion = alias.substring(underscoreIndex + 1);
+                if (log.isDebugEnabled()) {
+                    log.debug("Secret version found for " + secretName  + ". Retrieving the specified version of secret.");
+                }
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("Secret version not found for " + secretName  + ". Retrieving latest version of secret.");
+                }
+            }
+
             GetSecretValueRequest valueRequest = GetSecretValueRequest.builder()
-                    .secretId(alias)
+                    .secretId(secretName)
+                    .versionId(secretVersion)
                     .build();
 
             GetSecretValueResponse valueResponse = secretsClient.getSecretValue(valueRequest);
             secret = valueResponse.secretString();
 
-            if (StringUtils.isEmpty(secret)) {
-                log.error("Secret with alias " + alias + " not available in the AWS Secrets Manager Vault.");
-            }
-
             if (log.isDebugEnabled()) {
-                log.debug("Secret " + alias + " is retrieved");
+                log.debug("Secret " + secretName + " is retrieved");
             }
 
         } catch (SecretsManagerException e) {
-            log.error("Error retrieving secret with alias " + alias + " from AWS Secrets Manager Vault");
+            log.error("Error retrieving secret with alias " + secretName + " from AWS Secrets Manager Vault");
             log.error(e.awsErrorDetails().errorMessage());
         }
         return secret;


### PR DESCRIPTION
Secrets can be added with a "_" separator when specifying the alias. The versionID of the secret is used to get the version of the secret.